### PR TITLE
Fix replica command bug and Add kafka lib support to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Build Geth in a stock Go builder container
 FROM golang:1.9-alpine as builder
 
-RUN apk add --no-cache make gcc musl-dev linux-headers
+RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 ADD . /go-ethereum
+RUN cd /go-ethereum && build/env.sh go get -v -u github.com/Shopify/sarama
 RUN cd /go-ethereum && make geth
 
 # Pull Geth into a second stage deploy alpine container

--- a/cmd/geth/replicacmd.go
+++ b/cmd/geth/replicacmd.go
@@ -39,11 +39,11 @@ import (
 
 var (
 	replicaCommandBrokerFlag = cli.StringFlag{
-		Name:  "kafka.broker",
+		Name:  "kafka.source.broker",
 		Usage: "The Kafka Broker to pull change data from",
 	}
 	replicaCommandTopicFlag = cli.StringFlag{
-		Name:  "kafka.topic",
+		Name:  "kafka.source.topic",
 		Usage: "The Kafka Topic to pull change data from",
 	}
 	replicaCommand = cli.Command{
@@ -162,8 +162,8 @@ func makeReplicaNode(ctx *cli.Context) (*node.Node, gethConfig) {
 			chainDb,
 			&cfg.Eth,
 			sctx,
-			[]string{ctx.GlobalString(utils.KafkaLogSinkBrokerFlag.Name)},
-			ctx.GlobalString(utils.KafkaLogSinkTopicFlag.Name),
+			[]string{ctx.GlobalString(utils.KafkaLogSourceBrokerFlag.Name)},
+			ctx.GlobalString(utils.KafkaLogSourceTopicFlag.Name),
 		)
 	})
 	// replicaModule.ReplicaService)


### PR DESCRIPTION
`replica` command was trying to read from the sink broker instead of the source, the `kafka.sink.broker` param was starting the wrapper in write mode instead of read