### PR TITLE
Replica to have the ability for posting writes back to kafka MVP

### DIFF
--- a/REPLICA_TESTING.md
+++ b/REPLICA_TESTING.md
@@ -11,8 +11,8 @@
 
 ## Running with writable replica nodes
 
-Check out this code base so it lives at:
-`${HOME}/go/src/github.com/ethereum/go-ethereum/cmd/geth`
+Check out this code base so it lives at:  
+`${HOME}/go/src/github.com/ethereum/go-ethereum/cmd/geth`  
 
 Or look up overriding you `$GOPATH` https://github.com/golang/go/wiki/GOPATH
 
@@ -29,8 +29,8 @@ More details will be provided at bottom
 
 #### Prepare your genesis.json:
 
-For these steps, lives in the top level directory of this repository
-For version 1.9 and lower of geth, keep in mind your `chainId`
+For these steps, lives in the top level directory of this repository  
+For version 1.9 and lower of geth, keep in mind your `chainId`  
 
     {
       "config": {
@@ -52,9 +52,11 @@ For version 1.9 and lower of geth, keep in mind your `chainId`
 
 #### Seed the disk directories of the master and slave replica
 
-For this guide, we'll make the:
-  master node use /tmp/replicatest
-  slave replica use /tmp/replicatest2
+For this guide, we'll make the:  
+- master node use /tmp/replicatest  
+- slave replica use /tmp/replicatest2  
+
+eg:
 
     ./geth init --datadir=/tmp/replicatest ../../genesis.json
     ./geth init --datadir=/tmp/replicatest2 ../../genesis.json
@@ -67,19 +69,21 @@ For this guide, we'll make the:
 #### Run it
 
 
-Set the master flags up so:
+Set the master flags up so:  
+- `networkid` matches your `chainId` in the `genesis.json`  
+- specify the `genesis.json` you created earlier  
+- specify the data directory we seeded earlier  
+- use the flags: `--rpc --rpccorsdomain='*'` if doing testing on only the master node, won't do anything if we are enabling replicas  
 
-  `networkid` matches your `chainId` in the `genesis.json`
-  specify the `genesis.json` you created earlier
-  specify the data directory we seeded earlier
-  use the flags: `--rpc --rpccorsdomain='*'` if doing testing on only the master node, won't do anything if we are enabling replicas
+eg:
 
-    ./geth --kafka.broker=localhost:9092 --mine --miner.etherbase 1c522b369b0e5981a50687e97e442754538e3dfd --datadir=/tmp/replicatest/ --networkid=19870212 --miner.threads 1 --port 30304 --syncmode full --gcmode archive  
+    ./geth --kafka.broker=localhost:9092 --mine --miner.etherbase 1c522b369b0e5981a50687e97e442754538e3dfd --datadir=/tmp/replicatest/ --networkid=19870212 --miner.threads 1 --port 30304 --syncmode full --gcmode archive
 
-Set up the slave replica flags so:
+Set up the slave replica flags so:  
+- `kafka.tx.topic` is set to something, `txtest` is this example, otherwise you'll have read only replicas  
+- specify the data directory we seeded earlier  
 
-  `kafka.tx.topic` is set to something, `txtest` is this example, otherwise you'll have read only replicas
-  specify the data directory we seeded earlier
+eg:
 
     ./geth replica --kafka.tx.topic=txtest --kafka.broker=localhost:9092 --datadir=/tmp/replicatest2/
 
@@ -92,8 +96,8 @@ Set up the slave replica flags so:
 
 #### Try to submit an transaction
 
-Generate coins:
-Generate your account, and then restart your master, changing the flag for `miner.etherbase`
+Generate coins:  
+Generate your account, and then restart your master, changing the flag for `miner.etherbase`  
 
 Your transaction will be displayed on your kafaka server, and you should see it git spit out on the console when you run the command provided earlier.
 
@@ -105,8 +109,8 @@ Write an app, or do it by hand for testing
 
 doing it by hand:
 
-    geth attach /tmp/replicatest/geth.ipc
-    web3.personal.newAccount()
+    geth attach /tmp/replicatest/geth.ipc  
+    web3.personal.newAccount()  
 
 Take that account, and then restart your master, changing the flag for `miner.etherbase` ( Yes you do need coin for this )
 
@@ -121,19 +125,19 @@ Post your transaction to the master (Should have been obtained from the kafaka q
 # ISSUES ENCOUNTERED:
 ## Invalid Sender
 
-Your client is using the wrong `chainId` due to improperly configured `networkId`. Make sure they are the same. Master defaults to `1` if not set, and the read replcias are hard coded.
-This is due to a long outstanding issue since geth 1.6 and apps that infer the `chainId` , I'll post some reading material:
+Your client is using the wrong `chainId` due to improperly configured `networkId`. Make sure they are the same. Master defaults to `1` if not set, and the read replcias are hard coded.  
+This is due to a long outstanding issue since geth 1.6 and apps that infer the `chainId` , I'll post some reading material:  
 
-https://github.com/MetaMask/metamask-extension/issues/1722
-MetaMask can not send transactions to localhost:8545 · Issue #1722 · MetaMask/metamask-extension
+https://github.com/MetaMask/metamask-extension/issues/1722  
+MetaMask can not send transactions to localhost:8545 · Issue #1722 · MetaMask/metamask-extension  
 > i think geth 1.6 no longer defaults the net id to chain id, so we're hearing this issue recently. we dont currently have a way to query the chainId directly so have always used the network id
 
-https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
-ethereum/EIPs The Ethereum Improvement Proposal repository.
+https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md  
+ethereum/EIPs The Ethereum Improvement Proposal repository.  
 
 
-https://github.com/ethereumproject/go-ethereum/wiki/FAQ#what-is-the-difference-between-chain-id-chain-identity-and-network-id
-ethereumproject/go-ethereum FAQ
+https://github.com/ethereumproject/go-ethereum/wiki/FAQ#what-is-the-difference-between-chain-id-chain-identity-and-network-id  
+ethereumproject/go-ethereum FAQ  
 
 > Flags For Your Private Network
 > There are some command line options (also called "flags") that are necessary in order to make sure that your network is private.

--- a/REPLICA_TESTING.md
+++ b/REPLICA_TESTING.md
@@ -157,3 +157,10 @@ Create and unlock a default account, as described in manually posting to your ma
 This was encountered in geth command line shell
 
 Your unlocked default account needs funds to send transactions. I don't know why, but some reason this happened to me. mine on it for a sec by restarting master, and changing the mining address, as described above
+
+
+# Running for real:
+
+    geth replica --kafka.tx.topic=txtest --kafka.broker=10.142.0.3:32768
+
+    geth --kafka.broker=10.142.0.3:32768 --kafka.tx.topic=txtest --rpc --syncmode full --gcmode archive

--- a/REPLICA_TESTING.md
+++ b/REPLICA_TESTING.md
@@ -1,3 +1,4 @@
+## Short and sweet read replicacluster
     docker run --rm -p 2181:2181 -p 9092:9092 --env ADVERTISED_HOST=localhost --env ADVERTISED_PORT=9092 spotify/kafka
 
     ./geth init --datadir=/tmp/replicatest ../../genesis.json
@@ -6,3 +7,149 @@
 
     ./geth --kafka.broker=localhost:9092 --mine --miner.etherbase 5409ed021d9299bf6814279a6a1411a7e866a631 --datadir=/tmp/replicatest/ --networkid=19870212 --miner.threads 1 --port 30304 --syncmode full
     ./geth replica --kafka.broker=localhost:9092 --datadir=/tmp/replicatest2/
+
+
+## Running with writable replica nodes
+
+Check out this code base so it lives at:
+`${HOME}/go/src/github.com/ethereum/go-ethereum/cmd/geth`
+
+Or look up overriding you `$GOPATH` https://github.com/golang/go/wiki/GOPATH
+
+#### OPTIONAL workaround for apps that infer the chainId from networkId:
+
+If you're not going to use chainId `19870212`, edit the following file: `cmd/geth/replicacmd.go:80`
+
+More details will be provided at bottom
+
+
+#### Build it
+
+    go build cmd/geth
+
+#### Prepare your genesis.json:
+
+For these steps, lives in the top level directory of this repository
+For version 1.9 and lower of geth, keep in mind your `chainId`
+
+    {
+      "config": {
+            "chainId": 19870212,
+            "homesteadBlock": 0,
+            "eip155Block": 0,
+            "eip158Block": 0
+        },
+      "alloc"      : {},
+      "coinbase"   : "0x0000000000000000000000000000000000000000",
+      "difficulty" : "0x20000",
+      "extraData"  : "",
+      "gasLimit"   : "0x2fefd8",
+      "nonce"      : "0x0000000000000042",
+      "mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "timestamp"  : "0x00"
+    }
+
+#### Seed the disk directories of the master and slave replica
+
+For this guide, we'll make the:
+  master node use /tmp/replicatest
+  slave replica use /tmp/replicatest2
+
+    ./geth init --datadir=/tmp/replicatest ../../genesis.json
+    ./geth init --datadir=/tmp/replicatest2 ../../genesis.json
+
+
+#### Stand up a kafka server
+
+    docker run --rm -p 2181:2181 -p 9092:9092 --env ADVERTISED_HOST=localhost --env ADVERTISED_PORT=9092 spotify/kafka
+
+#### Run it
+
+
+Set the master flags up so:
+
+  `networkid` matches your `chainId` in the `genesis.json`
+  specify the `genesis.json` you created earlier
+  specify the data directory we seeded earlier
+  use the flags: `--rpc --rpccorsdomain='*'` if doing testing on only the master node, won't do anything if we are enabling replicas
+
+    ./geth --kafka.broker=localhost:9092 --mine --miner.etherbase 1c522b369b0e5981a50687e97e442754538e3dfd --datadir=/tmp/replicatest/ --networkid=19870212 --miner.threads 1 --port 30304 --syncmode full --gcmode archive  
+
+Set up the slave replica flags so:
+
+  `kafka.tx.topic` is set to something, `txtest` is this example, otherwise you'll have read only replicas
+  specify the data directory we seeded earlier
+
+    ./geth replica --kafka.tx.topic=txtest --kafka.broker=localhost:9092 --datadir=/tmp/replicatest2/
+
+
+#### Follow your kafka logs from the kafka docker container
+
+    docker exec -it {id} /bin/bash
+    ./opt/kafka_2.11-0.10.1.0/bin/kafka-console-consumer.sh  --zookeeper localhost:2181 --topic txtest --from-beginning
+
+
+#### Try to submit an transaction
+
+Generate coins:
+Generate your account, and then restart your master, changing the flag for `miner.etherbase`
+
+Your transaction will be displayed on your kafaka server, and you should see it git spit out on the console when you run the command provided earlier.
+
+*NOTE* You need to make sure you are running the **BETA** of Metamask if testing with it, so the chainId resolution will work properly. (Occurred to me when I was only running the master, this was the fix I had to do)
+
+#### Feed the transaction back into the master
+
+Write an app, or do it by hand for testing
+
+doing it by hand:
+
+    geth attach /tmp/replicatest/geth.ipc
+    web3.personal.newAccount()
+
+Take that account, and then restart your master, changing the flag for `miner.etherbase` ( Yes you do need coin for this )
+
+Post your transaction to the master (Should have been obtained from the kafaka queue. Posted earlier manually):
+
+    geth attach /tmp/replicatest/geth.ipc
+    web3.eth.defaultAccount = web3.eth.accounts[0]
+    personal.unlockAccount(web3.eth.defaultAccount)
+    web3.eth.sendTransaction({transaction})
+
+
+# ISSUES ENCOUNTERED:
+## Invalid Sender
+
+Your client is using the wrong `chainId` due to improperly configured `networkId`. Make sure they are the same. Master defaults to `1` if not set, and the read replcias are hard coded.
+This is due to a long outstanding issue since geth 1.6 and apps that infer the `chainId` , I'll post some reading material:
+
+https://github.com/MetaMask/metamask-extension/issues/1722
+MetaMask can not send transactions to localhost:8545 · Issue #1722 · MetaMask/metamask-extension
+> i think geth 1.6 no longer defaults the net id to chain id, so we're hearing this issue recently. we dont currently have a way to query the chainId directly so have always used the network id
+
+https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
+ethereum/EIPs The Ethereum Improvement Proposal repository.
+
+
+https://github.com/ethereumproject/go-ethereum/wiki/FAQ#what-is-the-difference-between-chain-id-chain-identity-and-network-id
+ethereumproject/go-ethereum FAQ
+
+> Flags For Your Private Network
+> There are some command line options (also called "flags") that are necessary in order to make sure that your network is private.
+> --nodiscover
+Use this to make sure that your node is not discoverable by people who do not manually add you. Otherwise, there is a chance that your node may be inadvertently added to a stranger's > node if they have the same genesis file and network id.
+
+**FIXED IN** https://github.com/ethereum/go-ethereum/pull/17617
+
+## Error: invalid address
+
+This was encountered in geth command line shell
+
+Create and unlock a default account, as described in manually posting to your master node transactions
+
+## Error: insufficient funds for gas * price + value
+
+This was encountered in geth command line shell
+
+Your unlocked default account needs funds to send transactions. I don't know why, but some reason this happened to me. mine on it for a sec by restarting master, and changing the mining address, as described above

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -50,6 +50,7 @@ var (
 			utils.DataDirFlag,
 			utils.KafkaLogTopicFlag,
 			utils.KafkaLogBrokerFlag,
+			utils.KafkaTransactionTopicFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -133,6 +133,7 @@ var (
 		configFileFlag,
 		utils.KafkaLogBrokerFlag,
 		utils.KafkaLogTopicFlag,
+		utils.KafkaTransactionTopicFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/replicacmd.go
+++ b/cmd/geth/replicacmd.go
@@ -50,6 +50,7 @@ system and acts as an RPC node based on the replicated data.
 		Flags: []cli.Flag{
 			utils.KafkaLogBrokerFlag,
 			utils.KafkaLogTopicFlag,
+			utils.KafkaTransactionTopicFlag,
 			utils.DataDirFlag,
 		},
 	}
@@ -76,7 +77,7 @@ system and acts as an RPC node based on the replicated data.
 			DatasetsInMem:  1,
 			DatasetsOnDisk: 2,
 		},
-		NetworkId:     1,
+		NetworkId:     19870212,
 		LightPeers:    0,
 		DatabaseCache: 0,
 		TrieCache:     0,
@@ -156,6 +157,7 @@ func makeReplicaNode(ctx *cli.Context) (*node.Node, gethConfig) {
 			sctx,
 			[]string{ctx.GlobalString(utils.KafkaLogBrokerFlag.Name)},
 			ctx.GlobalString(utils.KafkaLogTopicFlag.Name),
+			ctx.GlobalString(utils.KafkaTransactionTopicFlag.Name),
 		)
 	})
 	return stack, cfg

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -575,8 +575,13 @@ var (
 	}
 	KafkaLogTopicFlag = cli.StringFlag{
 		Name: "kafka.topic",
-		Usage: "Kafka broker hostname and port",
+		Usage: "Kafka broker replication topic name",
 		Value: "geth", // TODO: Maybe the default could be based on the Ethereum network we connect to
+	}
+	KafkaTransactionTopicFlag = cli.StringFlag{
+		Name: "kafka.tx.topic",
+		Usage: "Kafka transaction topic name",
+		Value: "",
 	}
 
 
@@ -971,6 +976,7 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	setNodeUserIdent(ctx, cfg)
 	cfg.KafkaLogBroker = ctx.GlobalString(KafkaLogBrokerFlag.Name)
 	cfg.KafkaLogTopic = ctx.GlobalString(KafkaLogTopicFlag.Name)
+	cfg.KafkaTransactionTopic = ctx.GlobalString(KafkaTransactionTopicFlag.Name)
 
 
 	switch {

--- a/node/config.go
+++ b/node/config.go
@@ -155,6 +155,7 @@ type Config struct {
 
 	KafkaLogBroker string `toml:",omitempty"`
 	KafkaLogTopic string `toml:",omitempty"`
+	KafkaTransactionTopic string `toml:",omitempty"`
 
 }
 

--- a/replica/backend.go
+++ b/replica/backend.go
@@ -2,6 +2,8 @@ package replica
 
 import (
   "context"
+  "errors"
+  "fmt"
   "math/big"
   "github.com/ethereum/go-ethereum/eth/downloader"
   "github.com/ethereum/go-ethereum/ethdb"
@@ -23,6 +25,7 @@ type ReplicaBackend struct {
   hc *core.HeaderChain
   chainConfig *params.ChainConfig
   bc *core.BlockChain
+  transactionProducer TransactionProducer
 }
 
 	// General Ethereum API
@@ -119,7 +122,11 @@ func (backend *ReplicaBackend) SubscribeChainSideEvent(ch chan<- core.ChainSideE
 
 	// Perhaps we can put these on a Kafka queue back to the full node?
 func (backend *ReplicaBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
-  return nil
+  if backend.transactionProducer == nil {
+    return errors.New("This api is not configured for accepting transactions")
+  }
+  fmt.Printf("%v", backend.transactionProducer)
+  return backend.transactionProducer.Emit(signedTx)
 }
 
 	// Read replicas won't have the p2p functionality, so these will be noops

--- a/replica/interface.go
+++ b/replica/interface.go
@@ -1,0 +1,10 @@
+package replica
+
+import (
+  "github.com/ethereum/go-ethereum/core/types"
+)
+
+type TransactionProducer interface {
+  Emit(marshall(*types.Transaction)) error
+  Close()
+}

--- a/replica/kafak.go
+++ b/replica/kafak.go
@@ -5,7 +5,8 @@ import (
   // "log"
   "fmt"
   "github.com/ethereum/go-ethereum/core/types"
-  "encoding/json"
+  "github.com/ethereum/go-ethereum/rlp"
+  // "encoding/hex"
 )
 
 type KafkaTransactionProducer struct {
@@ -19,7 +20,8 @@ func (producer *KafkaTransactionProducer) Close() {
 }
 
 func (producer *KafkaTransactionProducer) Emit(tx *types.Transaction) error {
-  txBytes, err := json.Marshal(tx)
+  txBytes, err := rlp.EncodeToBytes(tx)
+  fmt.Printf("%#x\n", txBytes)
   if err != nil {
     return err
   }

--- a/replica/kafak.go
+++ b/replica/kafak.go
@@ -1,0 +1,54 @@
+package replica
+
+import (
+  "github.com/Shopify/sarama"
+  // "log"
+  "fmt"
+  "github.com/ethereum/go-ethereum/core/types"
+  "encoding/json"
+)
+
+type KafkaTransactionProducer struct {
+  producer sarama.SyncProducer
+  // TODO;  sarama.SyncProducer
+  topic string
+}
+
+func (producer *KafkaTransactionProducer) Close() {
+  producer.producer.Close()
+}
+
+func (producer *KafkaTransactionProducer) Emit(tx *types.Transaction) error {
+  txBytes, err := json.Marshal(tx)
+  if err != nil {
+    return err
+  }
+  // select {
+    msg :=  &sarama.ProducerMessage{Topic: producer.topic, Value: sarama.ByteEncoder(txBytes)}
+    partition, offset, err := producer.producer.SendMessage(msg)
+    if err != nil {
+      return err
+    }
+    fmt.Printf("Message is stored in topic(%s)/partition(%d)/offset(%d)\n", producer.topic, partition, offset)
+
+  // }
+  return nil
+}
+
+func (producer *KafkaTransactionProducer) String() string {
+  return fmt.Sprintf("KafkaTransactionProducer Topic DEBUG: %v", producer.topic)
+}
+
+func NewKafkaTransactionProducerFromURLs(brokers []string, topic string) (TransactionProducer, error) {
+  config := sarama.NewConfig()
+  config.Producer.Return.Successes=true
+  producer, err := sarama.NewSyncProducer(brokers, config)
+  if err != nil {
+    return nil, err
+  }
+  return NewKafkaTransactionProducer(producer, topic), nil
+}
+
+func NewKafkaTransactionProducer(producer sarama.SyncProducer, topic string) (TransactionProducer) {
+  return &KafkaTransactionProducer{producer, topic}
+}

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -24,6 +24,7 @@ type Replica struct {
   hc *core.HeaderChain
   chainConfig *params.ChainConfig
   bc *core.BlockChain
+  transactionProducer TransactionProducer
 }
 
 func (r *Replica) Protocols() []p2p.Protocol {
@@ -35,6 +36,7 @@ func (r *Replica) APIs() []rpc.API {
     hc: r.hc,
     chainConfig: r.chainConfig,
     bc: r.bc,
+    transactionProducer: r.transactionProducer,
   }),
   rpc.API{
     Namespace: "net",
@@ -52,7 +54,8 @@ func (r *Replica) Stop() error {
   return nil
 }
 
-func NewReplica(db ethdb.Database, config *eth.Config, ctx *node.ServiceContext, kafkaSourceBroker []string, kafkaTopic string) (*Replica, error) {
+// TODO ADD THE CONFIGURATION HERE FOR TRIGGERING POSTBACK
+func NewReplica(db ethdb.Database, config *eth.Config, ctx *node.ServiceContext, kafkaSourceBroker []string, kafkaTopic, transactionTopic string) (*Replica, error) {
   offsetBytes, err := db.Get([]byte(fmt.Sprintf("cdc-log-%v-offset", kafkaTopic)))
   var offset int64
   var bytesRead int
@@ -69,6 +72,14 @@ func NewReplica(db ethdb.Database, config *eth.Config, ctx *node.ServiceContext,
   )
   if err != nil { return nil, err }
   fmt.Printf("Pre: %v\n", time.Now())
+  // TODO : CREATE THE PRODUCER HERE with if conditionals
+  transactionProducer, err := NewKafkaTransactionProducerFromURLs(
+    kafkaSourceBroker,
+    transactionTopic,
+  )
+  if err != nil {
+    return nil, err
+  }
   go func() {
     for operation := range consumer.Messages() {
       operation.Apply(db)
@@ -86,5 +97,5 @@ func NewReplica(db ethdb.Database, config *eth.Config, ctx *node.ServiceContext,
   if err != nil {
     return nil, err
   }
-  return &Replica{db, hc, chainConfig, bc}, nil
+  return &Replica{db, hc, chainConfig, bc, transactionProducer}, nil
 }


### PR DESCRIPTION
More documentation is on the REPLICA_TESTING.md for usage.

> This is a decent overhaul, where I used the changes made for
KafkaLogTopic as a base.

> Created similarly named KafkaTransactionTopic, flags, and etc.

> Changed the geth/chaincmd.go to use correct chainid due to
chainid not being a public function on this version of Geth

> Created syncronous kafka producer, instead of an async
since users would likely enjoy knowing their transaction sending failed.

> Extended the documentation so it can be repeated by others