### PR TITLE
Allow Replica server to shutdown when finished syncing

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -140,6 +140,7 @@ var (
 		utils.KafkaLogTopicFlag,
 		utils.KafkaTransactionTopicFlag,
 		utils.KafkaTransactionConsumerGroupFlag,
+		utils.ReplicaSyncShutdownFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/replicacmd.go
+++ b/cmd/geth/replicacmd.go
@@ -55,6 +55,7 @@ system and acts as an RPC node based on the replicated data.
 			utils.KafkaLogTopicFlag,
 			utils.KafkaTransactionTopicFlag,
 			utils.DataDirFlag,
+			utils.ReplicaSyncShutdownFlag,
 		},
 	}
 	replicaTxPoolConfig = core.TxPoolConfig{
@@ -160,6 +161,7 @@ func makeReplicaNode(ctx *cli.Context) (*node.Node, gethConfig) {
 			[]string{ctx.GlobalString(utils.KafkaLogBrokerFlag.Name)},
 			ctx.GlobalString(utils.KafkaLogTopicFlag.Name),
 			ctx.GlobalString(utils.KafkaTransactionTopicFlag.Name),
+			ctx.GlobalBool(utils.ReplicaSyncShutdownFlag.Name),
 		)
 	})
 	return stack, cfg

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -609,7 +609,10 @@ var (
 		Usage: "Kafka transaction consumer group name",
 		Value: "geth-tx",
 	}
-
+	ReplicaSyncShutdownFlag = cli.BoolFlag{
+		Name: "replica.syncshutdown",
+		Usage: "Shutdown replica when it has finished syncing from kafka",
+	}
 
 	// Metrics flags
 	MetricsEnabledFlag = cli.BoolFlag{
@@ -1017,6 +1020,7 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	cfg.KafkaLogBroker = ctx.GlobalString(KafkaLogBrokerFlag.Name)
 	cfg.KafkaLogTopic = ctx.GlobalString(KafkaLogTopicFlag.Name)
 	cfg.KafkaTransactionTopic = ctx.GlobalString(KafkaTransactionTopicFlag.Name)
+	cfg.ReplicaSyncShutdown = ctx.GlobalBool(ReplicaSyncShutdownFlag.Name)
 
 	setDataDir(ctx, cfg)
 

--- a/node/config.go
+++ b/node/config.go
@@ -161,6 +161,7 @@ type Config struct {
 	KafkaLogBroker string `toml:",omitempty"`
 	KafkaLogTopic string `toml:",omitempty"`
 	KafkaTransactionTopic string `toml:",omitempty"`
+	ReplicaSyncShutdown bool `toml:",omitempty"`
 
 }
 


### PR DESCRIPTION
Example usage:

```
$ ./geth replica --kafka.broker=localhost:9092 --datadir=/tmp/replicatest2/ --replica.syncshutdown
INFO [04-11|21:55:06.852] Maximum peer count                       ETH=0 LES=0 total=0
INFO [04-11|21:55:06.854] Starting peer-to-peer node               instance=Geth/v1.8.23-stable-92f9f885/linux-amd64/go1.12
INFO [04-11|21:55:06.854] Allocated cache and file handles         database=/tmp/replicatest2/geth/chaindata cache=16 handles=524288
INFO [04-11|21:55:06.887] Populating replica from topic            topic=geth offset=6291
INFO [04-11|21:55:06.919] Replica up to date 
INFO [04-11|21:55:06.919] Replica shutdown after sync flag was set, shutting down 
```