### PR TITLE
Add flag for replica to optionally not run rpc server

### DIFF
--- a/cmd/geth/replicacmd.go
+++ b/cmd/geth/replicacmd.go
@@ -56,6 +56,9 @@ system and acts as an RPC node based on the replicated data.
 			utils.KafkaTransactionTopicFlag,
 			utils.DataDirFlag,
 			utils.ReplicaSyncShutdownFlag,
+			utils.RPCEnabledFlag,
+			utils.RPCPortFlag,
+			utils.RPCListenAddrFlag,
 			utils.RPCCORSDomainFlag,
 			utils.ReplicaStartupMaxAgeFlag,
 			utils.ReplicaRuntimeMaxOffsetAgeFlag,
@@ -100,8 +103,8 @@ system and acts as an RPC node based on the replicated data.
 	}
 	nodeConfig = node.Config{
 		DataDir:          node.DefaultDataDir(),
-		HTTPHost:         "0.0.0.0",
-		HTTPPort:         node.DefaultHTTPPort,
+		// HTTPHost:         "0.0.0.0",
+		// HTTPPort:         node.DefaultHTTPPort,
 		HTTPModules:      []string{"net", "web3", "replica"},
 		HTTPVirtualHosts: []string{"*"},
 		WSPort:           node.DefaultWSPort,


### PR DESCRIPTION
Keep in mind, commands will need to be different in any tooling for starting the replica server. If you need to bind to 0.0.0.0 use the flags.

rpc
rpcaddr
rpcport

added to replica