### PR TITLE
The way defaults work make no sense 

### DIFF
--- a/cmd/geth/replicacmd.go
+++ b/cmd/geth/replicacmd.go
@@ -104,7 +104,7 @@ system and acts as an RPC node based on the replicated data.
 	nodeConfig = node.Config{
 		DataDir:          node.DefaultDataDir(),
 		// HTTPHost:         "0.0.0.0",
-		// HTTPPort:         node.DefaultHTTPPort,
+		HTTPPort:         node.DefaultHTTPPort,
 		HTTPModules:      []string{"net", "web3", "replica"},
 		HTTPVirtualHosts: []string{"*"},
 		WSPort:           node.DefaultWSPort,


### PR DESCRIPTION
I got RPC Port working, but I don't get why this works but the HTTPHost doesn't